### PR TITLE
fix: prevent double exception propagation in _waitFor

### DIFF
--- a/google_places_sdk_plus/CHANGELOG.md
+++ b/google_places_sdk_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.3
+
+* Fix: exceptions thrown by the library (e.g. network errors, API errors) were propagated twice — once to the caller's `try-catch` and again as an unhandled exception reaching `PlatformDispatcher.onError` / Crashlytics. Removed erroneous `throw` in `_waitFor` so errors are only delivered through the returned Future.
+
 ## 0.5.2
 
 * Fix: iOS build failure — `'flutter_google_places_sdk_ios-Swift.h' file not found`. Updated `google_places_sdk_plus_ios` to `0.3.1`.

--- a/google_places_sdk_plus/lib/google_places_sdk_plus.dart
+++ b/google_places_sdk_plus/lib/google_places_sdk_plus.dart
@@ -53,9 +53,9 @@ class FlutterGooglePlacesSdk {
   static Future<void> _waitFor(Future<void> future) {
     final Completer<void> completer = Completer<void>();
     future.whenComplete(completer.complete).catchError((dynamic err) {
-      // Ignore if previous call completed with an error.
+      // Error is already delivered to the caller via the original future.
+      // Swallow here to prevent an unhandled async error.
       log('FlutterGooglePlacesSdk::call error: $err');
-      throw err;
     });
     return completer.future;
   }

--- a/google_places_sdk_plus/pubspec.yaml
+++ b/google_places_sdk_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_places_sdk_plus
 description: A Flutter plugin for google places sdk that uses the native libraries on each platform
-version: 0.5.2
+version: 0.5.3
 homepage: https://github.com/KamiloChinome/google_places_sdk_plus/tree/master/google_places_sdk_plus
 
 environment:

--- a/google_places_sdk_plus/test/google_places_sdk_plus_test.dart
+++ b/google_places_sdk_plus/test/google_places_sdk_plus_test.dart
@@ -1,7 +1,8 @@
 import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
-import 'package:flutter/services.dart' show MethodCall, MethodChannel;
+import 'package:flutter/services.dart'
+    show MethodCall, MethodChannel, PlatformException;
 import 'package:google_places_sdk_plus/google_places_sdk_plus.dart';
 import 'package:google_places_sdk_plus_platform_interface/method_channel_google_places_sdk_plus.dart';
 import 'package:flutter_test/flutter_test.dart';
@@ -420,6 +421,47 @@ void main() {
         final call = log[1];
         expect(call.arguments['apiKey'], kDefaultApiKey);
         expect(flutterGooglePlacesSdk.apiKey, kDefaultApiKey);
+      });
+    });
+
+    group('error handling', () {
+      test('method call error is catchable', () async {
+        responses['isInitialized'] = Exception('test error');
+
+        expect(
+          () => flutterGooglePlacesSdk.isInitialized(),
+          throwsA(isA<PlatformException>()),
+        );
+      });
+
+      test('error in one call does not block subsequent calls', () async {
+        responses['isInitialized'] = Exception('first call error');
+
+        try {
+          await flutterGooglePlacesSdk.isInitialized();
+        } catch (_) {
+          // Expected
+        }
+
+        // Second call should succeed
+        responses['isInitialized'] = true;
+        final result = await flutterGooglePlacesSdk.isInitialized();
+        expect(result, isTrue);
+      });
+
+      test('error does not produce unhandled async exception', () async {
+        // If the bug existed, an unhandled exception from _waitFor's throw
+        // would cause this test to fail even though we caught the error.
+        responses['isInitialized'] = Exception('should not be unhandled');
+
+        try {
+          await flutterGooglePlacesSdk.isInitialized();
+        } catch (_) {
+          // Expected - this is the single, proper propagation
+        }
+
+        // Give the event loop a chance to surface any unhandled errors
+        await Future<void>.delayed(Duration.zero);
       });
     });
 


### PR DESCRIPTION
## Summary

- Removed erroneous `throw err` in `_waitFor` that caused exceptions to propagate twice — once to the caller's `try-catch` and again as an unhandled exception reaching `PlatformDispatcher.onError` / Crashlytics
- Added 3 error handling tests validating the fix
- Bumps version to 0.5.3

## Test plan

- [x] All 18 tests pass (`flutter test`)
- [x] New tests verify: errors are catchable, errors don't block subsequent calls, no unhandled async exceptions