### PR TITLE
fix: clear session token after fetchPlace & expose newSessionToken

### DIFF
--- a/google_places_sdk_plus/CHANGELOG.md
+++ b/google_places_sdk_plus/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.5.4
+
+* Fix: expose `newSessionToken` parameter in `fetchPlace()` — it was already defined in the platform interface but missing from the public API, preventing users from explicitly controlling session lifecycle.
+
 ## 0.5.3
 
 * Fix: exceptions thrown by the library (e.g. network errors, API errors) were propagated twice — once to the caller's `try-catch` and again as an unhandled exception reaching `PlatformDispatcher.onError` / Crashlytics. Removed erroneous `throw` in `_waitFor` so errors are only delivered through the returned Future.

--- a/google_places_sdk_plus/lib/google_places_sdk_plus.dart
+++ b/google_places_sdk_plus/lib/google_places_sdk_plus.dart
@@ -121,8 +121,13 @@ class FlutterGooglePlacesSdk {
   Future<FetchPlaceResponse> fetchPlace(
     String placeId, {
     required List<PlaceField> fields,
+    bool? newSessionToken,
   }) {
-    return _addMethodCall(() => platform.fetchPlace(placeId, fields: fields));
+    return _addMethodCall(() => platform.fetchPlace(
+          placeId,
+          fields: fields,
+          newSessionToken: newSessionToken,
+        ));
   }
 
   /// Fetches a photo of a place.

--- a/google_places_sdk_plus/pubspec.yaml
+++ b/google_places_sdk_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_places_sdk_plus
 description: A Flutter plugin for google places sdk that uses the native libraries on each platform
-version: 0.5.3
+version: 0.5.4
 homepage: https://github.com/KamiloChinome/google_places_sdk_plus/tree/master/google_places_sdk_plus
 
 environment:

--- a/google_places_sdk_plus_android/CHANGELOG.md
+++ b/google_places_sdk_plus_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.4.1
+
+* Fix: session token was not cleared after `fetchPlace()`, causing subsequent autocomplete searches to reuse a stale token and break session billing boundaries. The token is now invalidated after every `fetchPlace()` call.
+
 ## 0.4.0
 
 Initial release of `google_places_sdk_plus_android`.

--- a/google_places_sdk_plus_android/android/src/main/kotlin/io/google_places_sdk_plus/FlutterGooglePlacesSdkPlugin.kt
+++ b/google_places_sdk_plus_android/android/src/main/kotlin/io/google_places_sdk_plus/FlutterGooglePlacesSdkPlugin.kt
@@ -145,6 +145,10 @@ class FlutterGooglePlacesSdkPlugin : FlutterPlugin, MethodCallHandler {
                     .setRegionCode(regionCode)
                     .build()
                 client!!.fetchPlace(request).addOnCompleteListener { task ->
+                    // End session after fetchPlace (billing optimization).
+                    // The next autocomplete call will create a new session token.
+                    lastSessionToken = null
+
                     if (task.isSuccessful) {
                         val place = placeToMap(task.result?.place)
                         print("FetchPlace Result: $place")

--- a/google_places_sdk_plus_android/pubspec.yaml
+++ b/google_places_sdk_plus_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_places_sdk_plus_android
 description: A Flutter plugin for google places sdk that uses the native libraries on each platform
-version: 0.4.0
+version: 0.4.1
 homepage: https://github.com/KamiloChinome/google_places_sdk_plus/tree/master/google_places_sdk_plus_android
 
 environment:

--- a/google_places_sdk_plus_ios/CHANGELOG.md
+++ b/google_places_sdk_plus_ios/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.3.2
+
+* Fix: session token was not cleared after `fetchPlace()`, causing subsequent autocomplete searches to reuse a stale token and break session billing boundaries. The token is now invalidated after every `fetchPlace()` call.
+
 ## 0.3.1
 
 * Fix: Corrected Swift generated header import in `FlutterGooglePlacesSdkIosPlugin.m` — was referencing old module name `flutter_google_places_sdk_ios` instead of `google_places_sdk_plus_ios`, causing `'flutter_google_places_sdk_ios-Swift.h' file not found` build error.

--- a/google_places_sdk_plus_ios/ios/Classes/SwiftFlutterGooglePlacesSdkIosPlugin.swift
+++ b/google_places_sdk_plus_ios/ios/Classes/SwiftFlutterGooglePlacesSdkIosPlugin.swift
@@ -97,6 +97,10 @@ public class SwiftFlutterGooglePlacesSdkIosPlugin: NSObject, FlutterPlugin {
             let request = GMSFetchPlaceRequest(placeID: placeId, placeProperties: properties, sessionToken: sessionToken)
             
             placesClient.fetchPlace(with: request) { (place, error) in
+                // End session after fetchPlace (billing optimization).
+                // The next autocomplete call will create a new session token.
+                self.lastSessionToken = nil
+
                 if let error = error {
                     print("fetchPlace error: \(error)")
                     result(FlutterError(

--- a/google_places_sdk_plus_ios/pubspec.yaml
+++ b/google_places_sdk_plus_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_places_sdk_plus_ios
 description: The iOS implementation of Flutter plugin for google places sdk
-version: 0.3.1
+version: 0.3.2
 homepage: https://github.com/KamiloChinome/google_places_sdk_plus/tree/master/google_places_sdk_plus_ios
 
 environment:


### PR DESCRIPTION
## Summary

- **Android/iOS**: Invalidate session token after `fetchPlace()` so the next autocomplete call starts a fresh billing session, preventing stale token reuse that breaks session billing boundaries.
- **Main package**: Expose `newSessionToken` parameter in `fetchPlace()` — it was already defined in the platform interface but missing from the public API, preventing users from explicitly controlling session lifecycle.

## Version bumps

| Package | Old | New |
|---------|-----|-----|
| `google_places_sdk_plus` | 0.5.3 | 0.5.4 |
| `google_places_sdk_plus_android` | 0.4.0 | 0.4.1 |
| `google_places_sdk_plus_ios` | 0.3.1 | 0.3.2 |

## Test plan

- [ ] Verify autocomplete → fetchPlace → autocomplete flow uses separate billing sessions
- [ ] Verify `newSessionToken` parameter can be passed through from main package

🤖 Generated with [Claude Code](https://claude.com/claude-code)