### PR TITLE
Fix cross-platform inconsistencies and remove debug artifacts

### DIFF
--- a/google_places_sdk_plus/CHANGELOG.md
+++ b/google_places_sdk_plus/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.5.5
+
+* Fix cross-platform inconsistencies between Android and iOS native plugins:
+  * PriceLevel serialization now returns identical string values on both platforms
+  * Error codes are now consistent across platforms (`API_ERROR_AUTOCOMPLETE`, `API_ERROR_PLACE`, etc.)
+  * Removed all debug `print()` statements from native plugins
+  * Replaced unsafe force unwraps with proper error handling that returns `FlutterError`
+
 ## 0.5.4
 
 * Fix: expose `newSessionToken` parameter in `fetchPlace()` — it was already defined in the platform interface but missing from the public API, preventing users from explicitly controlling session lifecycle.

--- a/google_places_sdk_plus/pubspec.yaml
+++ b/google_places_sdk_plus/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_places_sdk_plus
 description: A Flutter plugin for google places sdk that uses the native libraries on each platform
-version: 0.5.4
+version: 0.5.5
 homepage: https://github.com/KamiloChinome/google_places_sdk_plus/tree/master/google_places_sdk_plus
 
 environment:

--- a/google_places_sdk_plus_android/CHANGELOG.md
+++ b/google_places_sdk_plus_android/CHANGELOG.md
@@ -1,3 +1,9 @@
+## 0.4.2
+
+* Remove all `print()` debug statements from native plugin
+* Replace force unwraps (`!!`) with safe null checks that return `FlutterError` instead of crashing
+* Add `requireClient()` guard — returns `CLIENT_NOT_INITIALIZED` error if called before `initialize()`
+
 ## 0.4.1
 
 * Fix: session token was not cleared after `fetchPlace()`, causing subsequent autocomplete searches to reuse a stale token and break session billing boundaries. The token is now invalidated after every `fetchPlace()` call.

--- a/google_places_sdk_plus_android/pubspec.yaml
+++ b/google_places_sdk_plus_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_places_sdk_plus_android
 description: A Flutter plugin for google places sdk that uses the native libraries on each platform
-version: 0.4.1
+version: 0.4.2
 homepage: https://github.com/KamiloChinome/google_places_sdk_plus/tree/master/google_places_sdk_plus_android
 
 environment:

--- a/google_places_sdk_plus_ios/CHANGELOG.md
+++ b/google_places_sdk_plus_ios/CHANGELOG.md
@@ -1,3 +1,11 @@
+## 0.3.3
+
+* Remove all `print()` debug statements from native plugin
+* Fix PriceLevel serialization to return string values matching Android (e.g. `"PRICE_LEVEL_MODERATE"` instead of raw int `2`)
+* Fix error codes: autocomplete now returns `API_ERROR_AUTOCOMPLETE` and fetchPlace returns `API_ERROR_PLACE` (both previously returned generic `API_ERROR`)
+* Replace force unwraps (`as!`) with safe `guard let` checks that return `FlutterError` instead of crashing
+* Fix implicitly unwrapped optional return type on `getSessionToken()`
+
 ## 0.3.2
 
 * Fix: session token was not cleared after `fetchPlace()`, causing subsequent autocomplete searches to reuse a stale token and break session billing boundaries. The token is now invalidated after every `fetchPlace()` call.

--- a/google_places_sdk_plus_ios/pubspec.yaml
+++ b/google_places_sdk_plus_ios/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_places_sdk_plus_ios
 description: The iOS implementation of Flutter plugin for google places sdk
-version: 0.3.2
+version: 0.3.3
 homepage: https://github.com/KamiloChinome/google_places_sdk_plus/tree/master/google_places_sdk_plus_ios
 
 environment:

--- a/google_places_sdk_plus_platform_interface/lib/src/types/price_level.dart
+++ b/google_places_sdk_plus_platform_interface/lib/src/types/price_level.dart
@@ -22,8 +22,9 @@ enum PriceLevel {
 
   factory PriceLevel.fromJson(dynamic value) {
     if (value is int) {
-      // iOS SDK sends priceLevel as an int (raw enum value)
-      // 0 = unspecified, 1 = free, 2 = inexpensive, 3 = moderate, 4 = expensive, 5 = very expensive
+      // Legacy: older iOS plugin versions (< 0.3.3) sent priceLevel as an int.
+      // Both platforms now send string values (e.g. "PRICE_LEVEL_MODERATE").
+      // Keeping int support for backward compatibility.
       if (value >= 0 && value < PriceLevel.values.length) {
         return PriceLevel.values[value];
       }


### PR DESCRIPTION
## Summary

Closes #13

- Remove all `print()` debug statements from Android (10) and iOS (6) native plugins
- Normalize PriceLevel serialization on iOS to return string values matching Android (e.g. `"PRICE_LEVEL_MODERATE"` instead of raw int `2`)
- Fix iOS error codes: autocomplete → `API_ERROR_AUTOCOMPLETE`, fetchPlace → `API_ERROR_PLACE` (both were generic `API_ERROR`)
- Replace all force unwraps (`!!` in Kotlin, `as!` in Swift) with safe guards returning `FlutterError`
- Bump `google_places_sdk_plus_android` 0.4.1 → 0.4.2, `google_places_sdk_plus_ios` 0.3.2 → 0.3.3, `google_places_sdk_plus` 0.5.4 → 0.5.5

## Acceptance Criteria (from #13)

- [x] No `print()` statements in Android plugin
- [x] PriceLevel serialization is identical on both platforms
- [x] Error codes match between Android and iOS
- [x] No force unwraps on method channel argument reads
- [x] Session token changes committed and released (done in PR #17)

## Test plan

- [x] Verify `grep -n "print(" FlutterGooglePlacesSdkPlugin.kt` returns 0 results
- [x] Verify `grep -n "print(" SwiftFlutterGooglePlacesSdkIosPlugin.swift` returns 0 results
- [x] Verify `grep -n "!!" FlutterGooglePlacesSdkPlugin.kt` returns 0 results
- [x] Verify `grep -n "as!" SwiftFlutterGooglePlacesSdkIosPlugin.swift` returns 0 results
- [x] Run `flutter analyze` on all packages — no errors
- [ ] Build and test on Android emulator — autocomplete, fetchPlace, searchByText, searchNearby
- [ ] Build and test on iOS simulator — same methods, verify priceLevel returns string
- [ ] Test calling API methods before `initialize()` — should return `CLIENT_NOT_INITIALIZED` error instead of crashing

🤖 Generated with [Claude Code](https://claude.com/claude-code)