### PR TITLE
fix(ci): bump Flutter 3.38.5 → 3.41.7 across workflows

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,7 @@ on:
         default: true
 
 env:
-  FLUTTER_VERSION: '3.38.5'
+  FLUTTER_VERSION: '3.41.7'
 
 jobs:
   validate:

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -26,7 +26,7 @@ on:
       - 'analysis_options.yaml'
 
 env:
-  FLUTTER_VERSION: '3.38.5'
+  FLUTTER_VERSION: '3.41.7'
 
 jobs:
   test:

--- a/.github/workflows/tests_android.yml
+++ b/.github/workflows/tests_android.yml
@@ -14,7 +14,7 @@ on:
       - 'analysis_options.yaml'
 
 env:
-  FLUTTER_VERSION: '3.38.5'
+  FLUTTER_VERSION: '3.41.7'
   JAVA_VERSION: '17'
 
 jobs:

--- a/.github/workflows/tests_integration.yml
+++ b/.github/workflows/tests_integration.yml
@@ -24,7 +24,7 @@ on:
       - 'google_places_sdk_plus_ios/**'
 
 env:
-  FLUTTER_VERSION: '3.38.5'
+  FLUTTER_VERSION: '3.41.7'
   JAVA_VERSION: '17'
 
 jobs:

--- a/.github/workflows/tests_ios.yml
+++ b/.github/workflows/tests_ios.yml
@@ -16,7 +16,7 @@ on:
       - 'analysis_options.yaml'
 
 env:
-  FLUTTER_VERSION: '3.38.5'
+  FLUTTER_VERSION: '3.41.7'
 
 jobs:
   dart-tests:


### PR DESCRIPTION
## Summary
- Every CI job has been failing since 1.1.0 (115fb6b) because all `pubspec.yaml` now require Dart >=3.11.0 / Flutter >=3.41.0, while workflows stayed pinned to Flutter 3.38.5 (Dart 3.10.4).
- Bumps `FLUTTER_VERSION` to `3.41.7` in all 5 workflows: `tests.yml`, `tests_android.yml`, `tests_ios.yml`, `tests_integration.yml`, `release.yml`.

## Test plan
- [x] Change is workflow-config only; `tests.yml` paths filter doesn't include `.github/workflows/**`, so no CI runs on this PR.
- [ ] After merge, verify the push-to-main Tests workflow passes on the next package touch (PR #28 merge).

🤖 Generated with [Claude Code](https://claude.com/claude-code)