### PR TITLE
fix(android): migrate to built-in Kotlin for AGP 9.0 compatibility

### DIFF
--- a/google_places_sdk_plus_android/CHANGELOG.md
+++ b/google_places_sdk_plus_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.1
+
+* Migrate to built-in Kotlin: the Kotlin Gradle Plugin is now only applied on Android Gradle Plugin (AGP) versions below 9.0. AGP 9.0+ removed support for plugins applying KGP directly, which broke builds for apps on Flutter 3.44+ (see flutter/flutter#181383). The plugin still builds on Flutter 3.41–3.43.
+
 ## 1.1.0
 
 * Update minimum SDK constraints: Dart >=3.11.0, Flutter >=3.41.0

--- a/google_places_sdk_plus_android/android/build.gradle
+++ b/google_places_sdk_plus_android/android/build.gradle
@@ -21,7 +21,16 @@ allprojects {
 }
 
 apply plugin: "com.android.library"
-apply plugin: "kotlin-android"
+
+// AGP 9.0+ removed support for a plugin applying the Kotlin Gradle Plugin (KGP)
+// directly; Flutter 3.44+ provides Kotlin built-in instead. Apply KGP manually
+// only on older AGP so this plugin keeps building on Flutter 3.41–3.43 while no
+// longer breaking apps that use AGP 9.0+ / built-in Kotlin.
+// https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+if (agpMajor < 9) {
+    apply plugin: "kotlin-android"
+}
 
 android {
     if (project.android.hasProperty("namespace")) {
@@ -32,10 +41,6 @@ android {
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_17
         targetCompatibility = JavaVersion.VERSION_17
-    }
-
-    kotlinOptions {
-        jvmTarget = JavaVersion.VERSION_17
     }
 
     sourceSets {
@@ -53,6 +58,12 @@ android {
     testOptions {
         unitTests.includeAndroidResources = true
         unitTests.returnDefaultValues = true
+    }
+}
+
+kotlin {
+    compilerOptions {
+        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
     }
 }
 

--- a/google_places_sdk_plus_android/pubspec.yaml
+++ b/google_places_sdk_plus_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_places_sdk_plus_android
 description: A Flutter plugin for google places sdk that uses the native libraries on each platform
-version: 1.1.0
+version: 1.1.1
 homepage: https://github.com/KamiloChinome/google_places_sdk_plus/tree/master/google_places_sdk_plus_android
 
 environment:


### PR DESCRIPTION
Closes #31

## Problem

Starting with Android Gradle Plugin (AGP) 9.0, support for a plugin applying the Kotlin Gradle Plugin (KGP) directly was removed. Because `google_places_sdk_plus_android` applied `kotlin-android` unconditionally, apps building on AGP 9.0+ / Flutter 3.44+ hit a compilation error (see [flutter/flutter#181383](https://github.com/flutter/flutter/issues/181383)).

## Fix

Per the Flutter [migrate-to-built-in-kotlin guide](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors), using the backward-compatible (conditional) variant so we don't have to drop support for Flutter 3.41–3.43:

- Apply `kotlin-android` only when AGP major version `< 9` (older toolchains still need it). On AGP 9.0+, Flutter provides Kotlin built-in.
- Move `jvmTarget` from the deprecated `android { kotlinOptions { } }` to a top-level `kotlin { compilerOptions { jvmTarget = JvmTarget.JVM_17 } }` block (same target: 17).

This keeps the plugin building on the currently supported range (Flutter 3.41+, AGP 8.x — what CI runs) while no longer breaking apps on AGP 9.0+.

## Validation

- `gradle help` configures cleanly locally with JDK 17 + AGP 8.4.1 (validates the conditional apply and the new `kotlin {}` block).
- Full Kotlin unit test run (`gradle testDebugUnitTest`) and Dart checks are gated by CI (`Tests (Android)`).

Patch release: `google_places_sdk_plus_android` 1.1.0 → 1.1.1.