### PR TITLE
fix(android): configure Kotlin jvmTarget via typed extension (#34)

### DIFF
--- a/google_places_sdk_plus_android/CHANGELOG.md
+++ b/google_places_sdk_plus_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.2
+
+* Fix Android build failure `Could not find method kotlin()` on Flutter 3.44+ / AGP 9.0+ (issue #34). The 1.1.1 built-in-Kotlin migration still relied on the top-level `kotlin { }` Groovy accessor, which is not registered when Kotlin is provided by Flutter's built-in Kotlin rather than the `kotlin-android` plugin. The `jvmTarget` is now set via the typed `KotlinAndroidProjectExtension`, configured once the Kotlin plugin is present, so the build works on both AGP 8.x and AGP 9.0+.
+
 ## 1.1.1
 
 * Migrate to built-in Kotlin: the Kotlin Gradle Plugin is now only applied on Android Gradle Plugin (AGP) versions below 9.0. AGP 9.0+ removed support for plugins applying KGP directly, which broke builds for apps on Flutter 3.44+ (see flutter/flutter#181383). The plugin still builds on Flutter 3.41–3.43.

--- a/google_places_sdk_plus_android/android/build.gradle
+++ b/google_places_sdk_plus_android/android/build.gradle
@@ -61,10 +61,27 @@ android {
     }
 }
 
-kotlin {
-    compilerOptions {
-        jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+// Set the Kotlin jvmTarget via the typed extension instead of the top-level
+// `kotlin { }` Groovy accessor. When Kotlin is provided by Flutter's built-in
+// Kotlin (AGP 9.0+ / Flutter 3.44+) rather than by the `kotlin-android` plugin
+// applied above, that accessor is not registered on the project and the build
+// failed with "Could not find method kotlin()" (issue #34). Configuring the
+// KotlinAndroidProjectExtension once the Kotlin plugin is present works whether
+// KGP was applied here (AGP < 9) or by Flutter (AGP 9.0+), and is skipped
+// silently if Kotlin is never applied.
+def configureKotlinJvmTarget = {
+    project.extensions.configure(org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension) {
+        it.compilerOptions {
+            jvmTarget = org.jetbrains.kotlin.gradle.dsl.JvmTarget.JVM_17
+        }
     }
+}
+if (agpMajor < 9) {
+    // The kotlin-android plugin was applied above, so the extension exists now.
+    configureKotlinJvmTarget()
+} else {
+    // Flutter's built-in Kotlin applies KGP; configure it once it is present.
+    project.plugins.withId("org.jetbrains.kotlin.android") { configureKotlinJvmTarget() }
 }
 
 dependencies {

--- a/google_places_sdk_plus_android/pubspec.yaml
+++ b/google_places_sdk_plus_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_places_sdk_plus_android
 description: A Flutter plugin for google places sdk that uses the native libraries on each platform
-version: 1.1.1
+version: 1.1.2
 homepage: https://github.com/KamiloChinome/google_places_sdk_plus/tree/master/google_places_sdk_plus_android
 
 environment:


### PR DESCRIPTION
## Summary

Fixes #34 — Android apps on **Flutter 3.44+ / AGP 9.0+** fail to build with:

```
Could not find method kotlin() for arguments [...]
on project ':google_places_sdk_plus_android'
```

The 1.1.1 built-in-Kotlin migration conditionally applied `kotlin-android` only on AGP < 9, but it **still used the top-level `kotlin { }` Groovy accessor** to set the `jvmTarget`. That accessor only exists when the `kotlin-android` plugin is applied on this project. On AGP 9.0+ Kotlin is provided by Flutter's *built-in Kotlin* instead, so the accessor is absent and evaluation of `build.gradle` line 64 throws.

## Fix

Set `jvmTarget` through the typed `KotlinAndroidProjectExtension` instead of the `kotlin { }` accessor, configured once the Kotlin plugin is actually present:

- **AGP < 9** — we apply `kotlin-android` above, so the extension exists; configure it directly.
- **AGP 9.0+** — configure via `project.plugins.withId("org.jetbrains.kotlin.android") { ... }` when Flutter's built-in Kotlin applies KGP (skipped silently if Kotlin is never applied).

This drops the fragile `kotlin { }` accessor entirely, matching the approach recommended in the issue and Flutter's [migrate-to-built-in-kotlin](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors) guide.

## Verification

- `./gradlew :google_places_sdk_plus_android:tasks` — build.gradle evaluates cleanly on AGP 8.13 (`agpMajor < 9` path). ✅
- `./gradlew :google_places_sdk_plus_android:compileDebugKotlin` — Kotlin compiles with `jvmTarget=17` applied, no JVM-target mismatch. ✅

## Release

Bumps `google_places_sdk_plus_android` **1.1.1 → 1.1.2** (1.1.1 is already published broken on pub.dev) + CHANGELOG entry. The umbrella `google_places_sdk_plus` package's `^1.0.0` constraint picks up 1.1.2 automatically, so no other package needs republishing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)