### PR TITLE
fix(android): apply KGP unless built-in Kotlin is enabled (#36)

### DIFF
--- a/google_places_sdk_plus_android/CHANGELOG.md
+++ b/google_places_sdk_plus_android/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 1.1.3
+
+* Fix Android build failure `cannot find symbol ... FlutterGooglePlacesSdkPlugin` in `GeneratedPluginRegistrant.java` (issue #36). The 1.1.1/1.1.2 migration decided whether to apply the Kotlin Gradle Plugin (KGP) from the AGP major version alone, assuming AGP 9.0+ always means built-in Kotlin compiles the plugin's Kotlin. But Flutter 3.44+ ships with built-in Kotlin **disabled** by default (`android.builtInKotlin=false` in the app's `gradle.properties`), even on AGP 9.0+. In that configuration KGP was skipped *and* built-in Kotlin was off, so the plugin's Kotlin was never compiled. The plugin now applies KGP unless the app has actually opted in to built-in Kotlin (`android.builtInKotlin=true`), which is the correct signal and keeps working on AGP 8.x and AGP 9.0+.
+
 ## 1.1.2
 
 * Fix Android build failure `Could not find method kotlin()` on Flutter 3.44+ / AGP 9.0+ (issue #34). The 1.1.1 built-in-Kotlin migration still relied on the top-level `kotlin { }` Groovy accessor, which is not registered when Kotlin is provided by Flutter's built-in Kotlin rather than the `kotlin-android` plugin. The `jvmTarget` is now set via the typed `KotlinAndroidProjectExtension`, configured once the Kotlin plugin is present, so the build works on both AGP 8.x and AGP 9.0+.

--- a/google_places_sdk_plus_android/android/build.gradle
+++ b/google_places_sdk_plus_android/android/build.gradle
@@ -22,13 +22,26 @@ allprojects {
 
 apply plugin: "com.android.library"
 
-// AGP 9.0+ removed support for a plugin applying the Kotlin Gradle Plugin (KGP)
-// directly; Flutter 3.44+ provides Kotlin built-in instead. Apply KGP manually
-// only on older AGP so this plugin keeps building on Flutter 3.41–3.43 while no
-// longer breaking apps that use AGP 9.0+ / built-in Kotlin.
+// Decide whether this plugin must apply the Kotlin Gradle Plugin (KGP) itself.
+//
+// AGP 9.0+ can compile Kotlin without KGP ("built-in Kotlin"), but Flutter 3.44+
+// ships with built-in Kotlin DISABLED by default: its migrator writes
+// `android.builtInKotlin=false` into the app's gradle.properties so legacy KGP
+// keeps working during the transition — and that holds even on AGP 9.0+.
+//
+// So the AGP major version alone can't tell us who compiles the Kotlin (issue
+// #36): on AGP 9 with built-in Kotlin off, skipping KGP leaves this plugin's
+// Kotlin uncompiled and the app fails with "cannot find symbol
+// FlutterGooglePlacesSdkPlugin" while building GeneratedPluginRegistrant.java.
+//
+// Rule: apply KGP unless the app has actually opted in to built-in Kotlin.
+// Flutter's temporary legacy-KGP support (flutter/flutter#183909) keeps applying
+// KGP valid on AGP 9.0+ while built-in Kotlin is disabled. `android.builtInKotlin`
+// is a root Gradle property, so it is visible from this plugin subproject and is
+// absent (→ KGP applied) for standalone Gradle / CI builds.
 // https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-plugin-authors
-def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
-if (agpMajor < 9) {
+def builtInKotlinEnabled = project.findProperty("android.builtInKotlin")?.toString()?.toBoolean() ?: false
+if (!builtInKotlinEnabled) {
     apply plugin: "kotlin-android"
 }
 
@@ -62,13 +75,12 @@ android {
 }
 
 // Set the Kotlin jvmTarget via the typed extension instead of the top-level
-// `kotlin { }` Groovy accessor. When Kotlin is provided by Flutter's built-in
-// Kotlin (AGP 9.0+ / Flutter 3.44+) rather than by the `kotlin-android` plugin
-// applied above, that accessor is not registered on the project and the build
-// failed with "Could not find method kotlin()" (issue #34). Configuring the
-// KotlinAndroidProjectExtension once the Kotlin plugin is present works whether
-// KGP was applied here (AGP < 9) or by Flutter (AGP 9.0+), and is skipped
-// silently if Kotlin is never applied.
+// `kotlin { }` Groovy accessor. When Kotlin is provided by the app's built-in
+// Kotlin rather than by the `kotlin-android` plugin applied above, that accessor
+// is not registered on the project and the build failed with "Could not find
+// method kotlin()" (issue #34). Configuring the KotlinAndroidProjectExtension
+// once the Kotlin plugin is present works whether KGP was applied here or by the
+// app's built-in Kotlin, and is skipped silently if Kotlin is never applied.
 def configureKotlinJvmTarget = {
     project.extensions.configure(org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension) {
         it.compilerOptions {
@@ -76,11 +88,11 @@ def configureKotlinJvmTarget = {
         }
     }
 }
-if (agpMajor < 9) {
-    // The kotlin-android plugin was applied above, so the extension exists now.
+if (!builtInKotlinEnabled) {
+    // We applied the kotlin-android plugin above, so the extension exists now.
     configureKotlinJvmTarget()
 } else {
-    // Flutter's built-in Kotlin applies KGP; configure it once it is present.
+    // The app's built-in Kotlin applies KGP; configure it once it is present.
     project.plugins.withId("org.jetbrains.kotlin.android") { configureKotlinJvmTarget() }
 }
 

--- a/google_places_sdk_plus_android/pubspec.yaml
+++ b/google_places_sdk_plus_android/pubspec.yaml
@@ -1,6 +1,6 @@
 name: google_places_sdk_plus_android
 description: A Flutter plugin for google places sdk that uses the native libraries on each platform
-version: 1.1.2
+version: 1.1.3
 homepage: https://github.com/KamiloChinome/google_places_sdk_plus/tree/master/google_places_sdk_plus_android
 
 environment:


### PR DESCRIPTION
## Problem

Building an Android app that uses this plugin fails during `:app:compileReleaseJavaWithJavac` while compiling `GeneratedPluginRegistrant.java`:

```
error: cannot find symbol
      flutterEngine.getPlugins().add(new io.google_places_sdk_plus.FlutterGooglePlacesSdkPlugin());
  symbol:   class FlutterGooglePlacesSdkPlugin
  location: package io.google_places_sdk_plus
```

Reported in #36.

## Root cause

The 1.1.1/1.1.2 built-in-Kotlin migration decided whether to apply the Kotlin Gradle Plugin (KGP) from the **AGP major version alone**:

```groovy
def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
if (agpMajor < 9) {
    apply plugin: "kotlin-android"
}
```

This assumes *AGP 9.0+ ⟹ built-in Kotlin compiles the plugin's Kotlin*. That assumption is wrong: **Flutter 3.44+ ships with built-in Kotlin disabled by default** — the Flutter migrator writes `android.builtInKotlin=false` into the app's `gradle.properties` so legacy KGP keeps working during the transition, **even on AGP 9.0+** (see the [app-developer migration guide](https://docs.flutter.dev/release/breaking-changes/migrate-to-built-in-kotlin/for-app-developers) and flutter/flutter#186800).

So on AGP 9 with `android.builtInKotlin=false`, KGP was skipped *and* built-in Kotlin was off → the plugin's Kotlin was never compiled → `cannot find symbol`.

## Fix

Apply KGP unless the app has **actually opted in** to built-in Kotlin (`android.builtInKotlin=true`) — the correct signal. `android.builtInKotlin` is a root Gradle property, visible from the plugin subproject, and absent (→ KGP applied) for standalone Gradle / CI builds. Flutter's temporary legacy-KGP support (flutter/flutter#183909) keeps applying KGP valid on AGP 9.0+ while built-in Kotlin is disabled.

```groovy
def builtInKotlinEnabled = project.findProperty("android.builtInKotlin")?.toString()?.toBoolean() ?: false
if (!builtInKotlinEnabled) {
    apply plugin: "kotlin-android"
}
```

Correct across all configurations:

| AGP | `android.builtInKotlin` | old (`agpMajor < 9`) | new (`!builtInKotlin`) |
|-----|------------------------|----------------------|------------------------|
| 8.x | absent | apply KGP ✅ | apply KGP ✅ |
| 9.x | `false` (Flutter default) | **skip → bug #36** ❌ | apply KGP ✅ |
| 9.x | `true` (migrated) | skip ✅ | skip ✅ |

## Verification

Standalone Gradle (Flutter 3.41.7 toolchain, AGP 8.4.1, JDK 17), same as CI:

- `-Pandroid.builtInKotlin=false` → `:compileDebugKotlin` runs, `:testDebugUnitTest` passes → **BUILD SUCCESSFUL**
- `-Pandroid.builtInKotlin=true` → no `compileDebugKotlin` task → KGP correctly skipped, deferring to built-in Kotlin
- `dart format --set-exit-if-changed`, `flutter analyze`, and `dart pub publish --dry-run` all pass

Bumps `google_places_sdk_plus_android` to **1.1.3**.

Closes #36

🤖 Generated with [Claude Code](https://claude.com/claude-code)